### PR TITLE
Fix missing fields

### DIFF
--- a/celerymon/__init__.py
+++ b/celerymon/__init__.py
@@ -156,7 +156,7 @@ def start_celerymon_worker_inspector(
                     )
         for tasks in (inspect.reserved() or {}).values():  # type: ignore[union-attr]
             for task in tasks:
-                task_count[("reserved", task["request"]["type"])] += 1
+                task_count[("reserved", task["type"])] += 1
         for tasks in (inspect.scheduled() or {}).values():  # type: ignore[union-attr]
             for task in tasks:
                 task_count[("scheduled", task["request"]["type"])] += 1


### PR DESCRIPTION
Reading the Celery code, it seems that dumping active and reserved
return the same info, and dumping scheduled task method returns
different types
(https://github.com/celery/celery/blob/fb0951866c2e388ea5a13822b3afde604323e7ef/celery/worker/control.py#L398-L441).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->
