### PR TITLE
Fix the labels in a metric

### DIFF
--- a/celerymon/metrics.py
+++ b/celerymon/metrics.py
@@ -100,7 +100,7 @@ def worker_metrics(watcher: WorkerWatcher) -> list[prometheus_client.Metric]:
                 timestamp=watcher.last_updated_timestamp.timestamp(),
             )
         for key, count in watcher.task_count.items():
-            task_name, state = key
+            state, task_name = key
             active_task_count_metric.add_metric(
                 labels=[task_name, state],
                 value=count,


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
