### PR TITLE
Remove an empty header in /healthz

### DIFF
--- a/celerymon/cli/__init__.py
+++ b/celerymon/cli/__init__.py
@@ -62,9 +62,9 @@ def run():
                 args.healthz_unhealthy_threshold_sec,
             )
             if stat == "":
-                start_response("200 OK", [("", "")])
+                start_response("200 OK", [])
                 return [b"OK"]
-            start_response("500 Internal Server Error", [("", "")])
+            start_response("500 Internal Server Error", [])
             return [stat.encode("utf-8")]
 
         return prom_app(environ, start_response)


### PR DESCRIPTION
See https://github.com/golang/go/issues/63168 for the background. With
this empty header, net/http will complain. Depending on the Go version
that is used in the health checker, this causes the health status to
fail.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
