### PR TITLE
replace celery State with lightweight uuid to name cache

### DIFF
--- a/celerymon/cli/__init__.py
+++ b/celerymon/cli/__init__.py
@@ -37,12 +37,7 @@ def run():
         redis_client, args.queue, args.redis_watch_interval_sec
     )
     worker_watcher = WorkerWatcher.create_started(app, args.worker_inspect_interval_sec)
-    event_watcher = EventWatcher.create_started(
-        app,
-        # This has a wrong type annotation.
-        app.events.State(),  # type: ignore[attr-defined]
-        buckets,
-    )
+    event_watcher = EventWatcher.create_started(app, buckets)
     collector = Collector(redis_watcher, worker_watcher, event_watcher)
 
     registry = prometheus_client.CollectorRegistry()

--- a/celerymon/event_watcher.py
+++ b/celerymon/event_watcher.py
@@ -5,11 +5,10 @@ import datetime
 import logging
 import threading
 import time
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from typing import Any, Sequence
 
-import celery.events  # type: ignore[import]
-import celery.events.state  # type: ignore[import]
+import celery  # type: ignore[import]
 
 from .timer import RepeatTimer
 
@@ -17,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class EventWatcher:
+    _TASK_NAMES_CACHE_LIMIT = 100_000
+
     last_received_timestamp: datetime.datetime | None
     last_received_timestamp_per_task_event: dict[tuple[str, str], datetime.datetime]
     num_events_per_task_count: dict[tuple[str, str], int]
@@ -29,10 +30,9 @@ class EventWatcher:
     def create_started(
         cls,
         app: celery.Celery,
-        state: celery.events.state.State,
         buckets: Sequence[float | str],
     ):
-        store = cls(state, buckets)
+        store = cls(buckets)
 
         def run() -> None:
             backoff = 1.0
@@ -67,10 +67,8 @@ class EventWatcher:
 
         return store
 
-    def __init__(
-        self, state: celery.events.state.State, buckets: Sequence[float | str]
-    ):
-        self._state = state
+    def __init__(self, buckets: Sequence[float | str]):
+        self._task_names_by_uuid: OrderedDict[str, str] = OrderedDict()
 
         self.upper_bounds = [float(b) for b in buckets]
         if self.upper_bounds and self.upper_bounds[-1] != float("inf"):
@@ -90,13 +88,18 @@ class EventWatcher:
         now = datetime.datetime.now(tz=datetime.UTC)
         self.last_received_timestamp = now
 
-        self._state.event(event)
         event_name: str = event["type"]
         if not event_name.startswith("task-"):
             return
 
-        task: celery.events.Task = self._state.get_or_create_task(event["uuid"])[0]
-        task_name = task.name or "(UNKNOWN)"
+        uuid: str = event["uuid"]
+        if "name" in event:
+            self._task_names_by_uuid.pop(uuid, None)
+            self._task_names_by_uuid[uuid] = event["name"]
+            while len(self._task_names_by_uuid) > self._TASK_NAMES_CACHE_LIMIT:
+                self._task_names_by_uuid.popitem(last=False)
+
+        task_name = self._task_names_by_uuid.get(uuid, "(UNKNOWN)")
         self.task_names.add(task_name)
 
         self.last_received_timestamp_per_task_event[(task_name, event_name)] = now


### PR DESCRIPTION
celerymon only needs task name from the State object, this replaces the full celery State (10k Task objects with 30+ fields, Worker objects, WeakSets, taskheap, mutex) with a simple OrderedDict mapping uuid to task name

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"event-watcher-reconnect","parentHead":"d181f72410aa078ebb2e5f7fb6a5db27a619a123","parentPull":20,"trunk":"main"}
```
-->
