### PR TITLE
use celerymon entrypoint directly instead of uv run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 ENV PATH="/app/.venv/bin:$PATH"
 
-ENTRYPOINT ["uv", "run", "celerymon"]
+ENTRYPOINT ["celerymon"]


### PR DESCRIPTION
uv run triggers a dep sync at startup which downloads dev deps and exceeds the 200Mi ephemeral storage limit, causing pod eviction loops

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
