### PR TITLE
add queue wait histogram, oldest queued age, in-flight cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ on the finished tasks. celerymon uses all these three to get the data.
 | `celerymon_events_count`                                  | Counter   | `task_name`, `event_name`        |
 | `celerymon_events_task_runtime_seconds`                   | Histogram | `task_name`, `result`            |
 | `celerymon_events_online_worker_count`                    | Gauge     |                                  |
+| `celerymon_events_queue_wait_seconds`                     | Histogram | `task_name`                      |
+| `celerymon_events_oldest_queued_task_age_seconds`         | Gauge     | `queue_name`                     |
+| `celerymon_events_in_flight_evicted`                      | Counter   | `reason`                         |
+| `celerymon_events_in_flight_cache_size`                   | Gauge     |                                  |
 
 There are timestamp metrics. These are meant to be used for checking the
 monitoring health. If this stops updating, it means that the monitoring cannot
@@ -90,6 +94,9 @@ celerymon --broker-url=BROKER_URL
           [--redis-watch-interval-sec=10]
           [--healthz-unhealthy-threshold-sec=300]
           [--success-task-runtime-buckets=BUCKETS]
+          [--queue-wait-buckets=BUCKETS]
+          [--in-flight-cache-size=100000]
+          [--in-flight-ttl-sec=3600]
           [--port=8000]
 ```
 
@@ -99,9 +106,25 @@ To monitor multiple queues, repeat the `--queue` flag:
 celerymon --broker-url=redis://localhost:6379/0 --queue=celery --queue=agent
 ```
 
-`--success-task-runtime-buckets` accepts a comma-separated list of bucket
-boundaries in seconds (e.g. `0.1,0.5,1,5,10`). If not specified, the default
-Prometheus histogram buckets are used.
+`--success-task-runtime-buckets` defines the histogram buckets for task
+runtime. Defaults to log-uniform buckets spanning 10ms to ~50 minutes
+(`0.01,0.03,0.1,0.3,1,3,10,30,100,300,1000,3000`), chosen to capture both
+fast webhook-style tasks and long-running batch work.
+
+`--queue-wait-buckets` defines the histogram buckets for queue wait time
+(time from task-sent to task-started). Defaults to log-uniform buckets
+spanning 3ms to ~17 minutes (`0.003,0.01,0.03,0.1,0.3,1,3,10,30,100,300,1000`),
+with extra sub-10ms resolution for distinguishing healthy queue states.
+
+`--in-flight-cache-size` caps the number of in-flight uuid→timestamp entries
+held for correlating task-sent with task-started. When the cap is hit, the
+oldest entry is evicted with reason `lru`.
+
+`--in-flight-ttl-sec` is the max age of an in-flight entry before it is
+treated as a zombie (task sent but never started or revoked) and evicted with
+reason `ttl`. Tasks whose `expires` timestamp passes are evicted earlier with
+reason `expired`. Eviction runs on a background timer every 30 seconds; metric
+scrapes stay pure reads.
 
 ### Note on /healthz
 

--- a/README.md
+++ b/README.md
@@ -107,24 +107,35 @@ celerymon --broker-url=redis://localhost:6379/0 --queue=celery --queue=agent
 ```
 
 `--success-task-runtime-buckets` defines the histogram buckets for task
-runtime. Defaults to log-uniform buckets spanning 10ms to ~50 minutes
-(`0.01,0.03,0.1,0.3,1,3,10,30,100,300,1000,3000`), chosen to capture both
-fast webhook-style tasks and long-running batch work.
+runtime. Defaults to `0.01,0.05,0.1,0.5,1,5,10,30,60,300,600,1800` (10ms to
+30 minutes), chosen to capture both fast webhook-style tasks and long-running
+batch work.
 
 `--queue-wait-buckets` defines the histogram buckets for queue wait time
-(time from task-sent to task-started). Defaults to log-uniform buckets
-spanning 3ms to ~17 minutes (`0.003,0.01,0.03,0.1,0.3,1,3,10,30,100,300,1000`),
-with extra sub-10ms resolution for distinguishing healthy queue states.
+(time from task-sent to task-started). Defaults to
+`0.005,0.01,0.05,0.1,0.5,1,5,10,60,300` (5ms to 5 minutes), with extra
+sub-10ms resolution for distinguishing healthy queue states.
 
 `--in-flight-cache-size` caps the number of in-flight uuid→timestamp entries
-held for correlating task-sent with task-started. When the cap is hit, the
-oldest entry is evicted with reason `lru`.
+held for correlating task-sent with task-started.
 
 `--in-flight-ttl-sec` is the max age of an in-flight entry before it is
-treated as a zombie (task sent but never started or revoked) and evicted with
-reason `ttl`. Tasks whose `expires` timestamp passes are evicted earlier with
-reason `expired`. Eviction runs on a background timer every 30 seconds; metric
-scrapes stay pure reads.
+treated as a zombie (task sent but never started or revoked). Eviction runs
+on a background timer every 30 seconds; metric scrapes stay pure reads.
+
+The `celerymon_events_in_flight_evicted{reason}` counter tracks why entries
+left the in-flight cache:
+
+* `lru` — evicted on insertion because `--in-flight-cache-size` was reached.
+* `failed_pre_start` — `task-failed` event arrived for an entry that never
+  transitioned to `task-started`. Tasks that started and then failed are not
+  counted here.
+* `revoked_pre_start` — `task-revoked` event arrived for an entry that never
+  transitioned to `task-started`.
+* `expired` — the producer-set `expires` timestamp on the task passed.
+* `ttl` — the entry exceeded `--in-flight-ttl-sec`. Use this counter to alarm
+  on stuck queues; the `celerymon_events_oldest_queued_task_age_seconds`
+  gauge does not include entries past TTL.
 
 ### Note on /healthz
 

--- a/README.md
+++ b/README.md
@@ -63,16 +63,17 @@ on the finished tasks. celerymon uses all these three to get the data.
 
 ## Metrics
 
-| Name                                                      | Type      | Labels                    |
-|-----------------------------------------------------------|-----------|---------------------------|
-| `celerymon_redis_last_updated_timestamp_seconds`          | Gauge     |                           |
-| `celerymon_redis_queue_item_count`                        | Gauge     | `queue_name`, `priority`  |
-| `celerymon_inspect_last_updated_timestamp_seconds`        | Gauge     |                           |
-| `celerymon_inspect_oldest_started_task_timestamp_seconds` | Gauge     | `task_name`               |
-| `celerymon_inspect_worker_held_task_count`                | Gauge     | `task_name`, `state`      |
-| `celerymon_events_last_received_timestamp_seconds`        | Gauge     | `task_name`, `event_name` |
-| `celerymon_events_count`                                  | Counter   | `task_name`, `event_name` |
-| `celerymon_events_success_task_runtime_seconds`           | Histogram | `task_name`               |
+| Name                                                      | Type      | Labels                           |
+|-----------------------------------------------------------|-----------|----------------------------------|
+| `celerymon_redis_last_updated_timestamp_seconds`          | Gauge     |                                  |
+| `celerymon_redis_queue_item_count`                        | Gauge     | `queue_name`, `priority`         |
+| `celerymon_inspect_last_updated_timestamp_seconds`        | Gauge     |                                  |
+| `celerymon_inspect_oldest_started_task_timestamp_seconds` | Gauge     | `task_name`                      |
+| `celerymon_inspect_worker_held_task_count`                | Gauge     | `task_name`, `state`, `hostname` |
+| `celerymon_events_last_received_timestamp_seconds`        | Gauge     | `task_name`, `event_name`        |
+| `celerymon_events_count`                                  | Counter   | `task_name`, `event_name`        |
+| `celerymon_events_task_runtime_seconds`                   | Histogram | `task_name`, `result`            |
+| `celerymon_events_online_worker_count`                    | Gauge     |                                  |
 
 There are timestamp metrics. These are meant to be used for checking the
 monitoring health. If this stops updating, it means that the monitoring cannot

--- a/celerymon/cli/__init__.py
+++ b/celerymon/cli/__init__.py
@@ -24,11 +24,23 @@ def run():
     parser.add_argument("--worker-inspect-interval-sec", type=int, default=10)
     parser.add_argument("--redis-watch-interval-sec", type=int, default=10)
     parser.add_argument("--healthz-unhealthy-threshold-sec", type=int, default=300)
-    parser.add_argument("--success-task-runtime-buckets", type=str)
+    parser.add_argument(
+        "--success-task-runtime-buckets",
+        type=str,
+        default="0.01,0.03,0.1,0.3,1,3,10,30,100,300,1000,3000",
+    )
+    parser.add_argument(
+        "--queue-wait-buckets",
+        type=str,
+        default="0.003,0.01,0.03,0.1,0.3,1,3,10,30,100,300,1000",
+    )
+    parser.add_argument("--in-flight-cache-size", type=int, default=100_000)
+    parser.add_argument("--in-flight-ttl-sec", type=int, default=3600)
     parser.add_argument("--port", type=int, default=8000)
     args = parser.parse_args()
 
     buckets = parse_histogram_buckets(args.success_task_runtime_buckets)
+    queue_wait_buckets = parse_histogram_buckets(args.queue_wait_buckets)
 
     app = celery.Celery("", broker=args.broker_url)
     redis_client = redis.StrictRedis.from_url(args.broker_url)
@@ -37,7 +49,13 @@ def run():
         redis_client, args.queue, args.redis_watch_interval_sec
     )
     worker_watcher = WorkerWatcher.create_started(app, args.worker_inspect_interval_sec)
-    event_watcher = EventWatcher.create_started(app, buckets)
+    event_watcher = EventWatcher.create_started(
+        app,
+        buckets,
+        queue_wait_buckets,
+        args.in_flight_cache_size,
+        args.in_flight_ttl_sec,
+    )
     collector = Collector(redis_watcher, worker_watcher, event_watcher)
 
     registry = prometheus_client.CollectorRegistry()

--- a/celerymon/cli/__init__.py
+++ b/celerymon/cli/__init__.py
@@ -27,12 +27,12 @@ def run():
     parser.add_argument(
         "--success-task-runtime-buckets",
         type=str,
-        default="0.01,0.03,0.1,0.3,1,3,10,30,100,300,1000,3000",
+        default="0.01,0.05,0.1,0.5,1,5,10,30,60,300,600,1800",
     )
     parser.add_argument(
         "--queue-wait-buckets",
         type=str,
-        default="0.003,0.01,0.03,0.1,0.3,1,3,10,30,100,300,1000",
+        default="0.005,0.01,0.05,0.1,0.5,1,5,10,60,300",
     )
     parser.add_argument("--in-flight-cache-size", type=int, default=100_000)
     parser.add_argument("--in-flight-ttl-sec", type=int, default=3600)

--- a/celerymon/event_watcher.py
+++ b/celerymon/event_watcher.py
@@ -6,13 +6,44 @@ import logging
 import threading
 import time
 from collections import OrderedDict, defaultdict
-from typing import Any, Sequence
+from typing import Any, NamedTuple, Sequence
 
 import celery
 
 from .timer import RepeatTimer
 
 logger = logging.getLogger(__name__)
+
+_WORKER_HEARTBEAT_TTL_SEC = 120
+_PRUNE_INTERVAL_SEC = 30
+
+
+def _normalize_buckets(buckets: Sequence[float | str]) -> list[float]:
+    bounds = [float(b) for b in buckets]
+    if bounds and bounds[-1] != float("inf"):
+        bounds.append(float("inf"))
+    bounds.sort()
+    return bounds
+
+
+def _parse_expires(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return datetime.datetime.fromisoformat(value).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+class InFlightEntry(NamedTuple):
+    sent_ts: float
+    task_name: str
+    queue_name: str | None
+    expires_ts: float | None
 
 
 class EventWatcher:
@@ -25,14 +56,22 @@ class EventWatcher:
     task_names: set[str]
     task_runtime_sec: list[dict[tuple[str, str], int]]
     task_runtime_sec_sum: dict[tuple[str, str], float]
+    queue_wait_upper_bounds: list[float]
+    queue_wait_sec: list[dict[str, int]]
+    queue_wait_sec_sum: dict[str, float]
 
     @classmethod
     def create_started(
         cls,
         app: celery.Celery,
         buckets: Sequence[float | str],
+        queue_wait_buckets: Sequence[float | str],
+        in_flight_cache_size: int,
+        in_flight_ttl_sec: int,
     ):
-        store = cls(buckets)
+        store = cls(
+            buckets, queue_wait_buckets, in_flight_cache_size, in_flight_ttl_sec
+        )
 
         def run() -> None:
             backoff = 1.0
@@ -58,9 +97,19 @@ class EventWatcher:
             except Exception:
                 logger.exception("Failed to enable events")
 
+        def prune() -> None:
+            try:
+                store._prune(datetime.datetime.now(tz=datetime.UTC))
+            except Exception:
+                logger.exception("EventWatcher prune failed")
+
         timer = RepeatTimer(10, update_enable_event)
         timer.daemon = True
         timer.start()
+
+        prune_timer = RepeatTimer(_PRUNE_INTERVAL_SEC, prune)
+        prune_timer.daemon = True
+        prune_timer.start()
 
         thread = threading.Thread(
             target=run, daemon=True, name="celerymon-event-watcher"
@@ -69,14 +118,22 @@ class EventWatcher:
 
         return store
 
-    def __init__(self, buckets: Sequence[float | str]):
+    def __init__(
+        self,
+        buckets: Sequence[float | str],
+        queue_wait_buckets: Sequence[float | str],
+        in_flight_cache_size: int,
+        in_flight_ttl_sec: int,
+    ):
         self._task_names_by_uuid: OrderedDict[str, str] = OrderedDict()
         self._worker_last_heartbeat: dict[str, datetime.datetime] = dict()
+        self._in_flight: OrderedDict[str, InFlightEntry] = OrderedDict()
+        self._in_flight_cache_size = in_flight_cache_size
+        self._in_flight_ttl_sec = in_flight_ttl_sec
+        self._eviction_counts: dict[str, int] = defaultdict(int)
 
-        self.upper_bounds = [float(b) for b in buckets]
-        if self.upper_bounds and self.upper_bounds[-1] != float("inf"):
-            self.upper_bounds.append(float("inf"))
-        self.upper_bounds.sort()
+        self.upper_bounds = _normalize_buckets(buckets)
+        self.queue_wait_upper_bounds = _normalize_buckets(queue_wait_buckets)
         self.task_names = set()
 
         self.last_received_timestamp = None
@@ -86,6 +143,10 @@ class EventWatcher:
             defaultdict(int) for _ in range(len(self.upper_bounds))
         ]
         self.task_runtime_sec_sum = defaultdict(float)
+        self.queue_wait_sec = [
+            defaultdict(int) for _ in range(len(self.queue_wait_upper_bounds))
+        ]
+        self.queue_wait_sec_sum = defaultdict(float)
 
     def on_event(self, event: dict[str, Any]):
         now = datetime.datetime.now(tz=datetime.UTC)
@@ -113,10 +174,22 @@ class EventWatcher:
         self.last_received_timestamp_per_task_event[(task_name, event_name)] = now
         self.num_events_per_task_count[(task_name, event_name)] += 1
 
+        if event_name == "task-sent":
+            self._record_task_sent(uuid, task_name, event)
+
+        if event_name == "task-started":
+            self._record_task_started(uuid, task_name, event)
+
+        if event_name == "task-revoked":
+            if self._in_flight.pop(uuid, None) is not None:
+                self._eviction_counts["revoked_pre_start"] += 1
+
         if event_name == "task-succeeded":
             self._record_task_runtime(task_name, "success", event)
 
         if event_name == "task-failed":
+            if self._in_flight.pop(uuid, None) is not None:
+                self._eviction_counts["failed_pre_start"] += 1
             self._record_task_runtime(task_name, "failed", event)
 
     def _on_worker_event(
@@ -136,7 +209,7 @@ class EventWatcher:
     def online_worker_count(
         self,
         now: datetime.datetime,
-        ttl_sec: int = 120,
+        ttl_sec: int = _WORKER_HEARTBEAT_TTL_SEC,
     ) -> int:
         cutoff = now - datetime.timedelta(seconds=ttl_sec)
         heartbeats = tuple(self._worker_last_heartbeat.values())
@@ -164,3 +237,95 @@ class EventWatcher:
         for i, bound in enumerate(self.upper_bounds):
             if runtime_sec <= bound:
                 self.task_runtime_sec[i][key] += 1
+
+    def _record_task_sent(
+        self,
+        uuid: str,
+        task_name: str,
+        event: dict[str, Any],
+    ) -> None:
+        sent_ts = event.get("timestamp")
+        if sent_ts is None:
+            return
+        self._in_flight.pop(uuid, None)
+        self._in_flight[uuid] = InFlightEntry(
+            sent_ts=float(sent_ts),
+            task_name=task_name,
+            queue_name=event.get("queue"),
+            expires_ts=_parse_expires(event.get("expires")),
+        )
+        while len(self._in_flight) > self._in_flight_cache_size:
+            self._in_flight.popitem(last=False)
+            self._eviction_counts["lru"] += 1
+
+    def _record_task_started(
+        self,
+        uuid: str,
+        task_name: str,
+        event: dict[str, Any],
+    ) -> None:
+        entry = self._in_flight.pop(uuid, None)
+        if entry is None:
+            return
+        started_ts = event.get("timestamp")
+        if started_ts is None:
+            return
+        wait_sec = float(started_ts) - entry.sent_ts
+        if wait_sec < 0:
+            return
+        self.queue_wait_sec_sum[task_name] += wait_sec
+        for i, bound in enumerate(self.queue_wait_upper_bounds):
+            if wait_sec <= bound:
+                self.queue_wait_sec[i][task_name] += 1
+
+    def oldest_queued_age_by_queue(
+        self,
+        now: datetime.datetime,
+    ) -> dict[str, float]:
+        """Pure read: walks the in-flight cache, returns per-queue max age of
+        entries that are still eligible (not expired, not past TTL). Does not
+        mutate state; eviction happens on the prune timer.
+        """
+        now_ts = now.timestamp()
+        ttl_cutoff = now_ts - self._in_flight_ttl_sec
+        ages: dict[str, float] = {}
+        for entry in self._in_flight.values():
+            if entry.expires_ts is not None and entry.expires_ts < now_ts:
+                continue
+            if entry.sent_ts < ttl_cutoff:
+                continue
+            if entry.queue_name is None:
+                continue
+            age = now_ts - entry.sent_ts
+            current = ages.get(entry.queue_name)
+            if current is None or age > current:
+                ages[entry.queue_name] = age
+        return ages
+
+    def _prune(self, now: datetime.datetime) -> None:
+        """Evict expired / past-TTL in-flight entries and stale worker
+        heartbeats. Runs on its own timer so that metric collection stays a
+        pure read.
+        """
+        now_ts = now.timestamp()
+        ttl_cutoff = now_ts - self._in_flight_ttl_sec
+        to_evict: list[tuple[str, str]] = []
+        for uuid, entry in list(self._in_flight.items()):
+            if entry.expires_ts is not None and entry.expires_ts < now_ts:
+                to_evict.append((uuid, "expired"))
+            elif entry.sent_ts < ttl_cutoff:
+                to_evict.append((uuid, "ttl"))
+        for uuid, reason in to_evict:
+            if self._in_flight.pop(uuid, None) is not None:
+                self._eviction_counts[reason] += 1
+
+        heartbeat_cutoff = now - datetime.timedelta(seconds=_WORKER_HEARTBEAT_TTL_SEC)
+        for hostname, ts in list(self._worker_last_heartbeat.items()):
+            if ts <= heartbeat_cutoff:
+                self._worker_last_heartbeat.pop(hostname, None)
+
+    def eviction_counts(self) -> dict[str, int]:
+        return dict(self._eviction_counts)
+
+    def in_flight_cache_size(self) -> int:
+        return len(self._in_flight)

--- a/celerymon/event_watcher.py
+++ b/celerymon/event_watcher.py
@@ -23,8 +23,8 @@ class EventWatcher:
     num_events_per_task_count: dict[tuple[str, str], int]
     upper_bounds: list[float]
     task_names: set[str]
-    succeeded_task_runtime_sec: list[dict[str, int]]
-    succeeded_task_runtime_sec_sum: dict[str, float]
+    task_runtime_sec: list[dict[tuple[str, str], int]]
+    task_runtime_sec_sum: dict[tuple[str, str], float]
 
     @classmethod
     def create_started(
@@ -71,6 +71,7 @@ class EventWatcher:
 
     def __init__(self, buckets: Sequence[float | str]):
         self._task_names_by_uuid: OrderedDict[str, str] = OrderedDict()
+        self._worker_last_heartbeat: dict[str, datetime.datetime] = dict()
 
         self.upper_bounds = [float(b) for b in buckets]
         if self.upper_bounds and self.upper_bounds[-1] != float("inf"):
@@ -81,16 +82,21 @@ class EventWatcher:
         self.last_received_timestamp = None
         self.last_received_timestamp_per_task_event = dict()
         self.num_events_per_task_count = defaultdict(int)
-        self.succeeded_task_runtime_sec = []
-        self.succeeded_task_runtime_sec_sum = defaultdict(float)
-        for _ in range(0, len(self.upper_bounds)):
-            self.succeeded_task_runtime_sec.append(defaultdict(int))
+        self.task_runtime_sec = [
+            defaultdict(int) for _ in range(len(self.upper_bounds))
+        ]
+        self.task_runtime_sec_sum = defaultdict(float)
 
     def on_event(self, event: dict[str, Any]):
         now = datetime.datetime.now(tz=datetime.UTC)
         self.last_received_timestamp = now
 
         event_name: str = event["type"]
+
+        if event_name.startswith("worker-"):
+            self._on_worker_event(event_name, event, now)
+            return
+
         if not event_name.startswith("task-"):
             return
 
@@ -108,10 +114,52 @@ class EventWatcher:
         self.num_events_per_task_count[(task_name, event_name)] += 1
 
         if event_name == "task-succeeded":
-            # Not documented, but looking into the Celery codebase, the runtime
-            # looks like seconds.
-            runtime_sec = event["runtime"]
-            self.succeeded_task_runtime_sec_sum[task_name] += runtime_sec
-            for i, bound in enumerate(self.upper_bounds):
-                if runtime_sec <= bound:
-                    self.succeeded_task_runtime_sec[i][task_name] += 1
+            self._record_task_runtime(task_name, "success", event)
+
+        if event_name == "task-failed":
+            self._record_task_runtime(task_name, "failed", event)
+
+    def _on_worker_event(
+        self,
+        event_name: str,
+        event: dict[str, Any],
+        now: datetime.datetime,
+    ) -> None:
+        hostname = event.get("hostname")
+        if not hostname:
+            return
+        if event_name == "worker-offline":
+            self._worker_last_heartbeat.pop(hostname, None)
+        else:
+            self._worker_last_heartbeat[hostname] = now
+
+    def online_worker_count(
+        self,
+        now: datetime.datetime,
+        ttl_sec: int = 120,
+    ) -> int:
+        cutoff = now - datetime.timedelta(seconds=ttl_sec)
+        return sum(1 for ts in self._worker_last_heartbeat.values() if ts > cutoff)
+
+    def _record_task_runtime(
+        self,
+        task_name: str,
+        result: str,
+        event: dict[str, Any],
+    ) -> None:
+        # Celery sets `runtime` (seconds) on task-succeeded consistently, and on
+        # task-failed when the task actually ran. Defensive `.get()` handles
+        # failure modes where the task never executed.
+        runtime_sec = event.get("runtime")
+        if runtime_sec is None:
+            logger.debug(
+                "task event missing runtime field; task_name=%s result=%s",
+                task_name,
+                result,
+            )
+            return
+        key = (task_name, result)
+        self.task_runtime_sec_sum[key] += runtime_sec
+        for i, bound in enumerate(self.upper_bounds):
+            if runtime_sec <= bound:
+                self.task_runtime_sec[i][key] += 1

--- a/celerymon/event_watcher.py
+++ b/celerymon/event_watcher.py
@@ -139,7 +139,8 @@ class EventWatcher:
         ttl_sec: int = 120,
     ) -> int:
         cutoff = now - datetime.timedelta(seconds=ttl_sec)
-        return sum(1 for ts in self._worker_last_heartbeat.values() if ts > cutoff)
+        heartbeats = tuple(self._worker_last_heartbeat.values())
+        return sum(1 for ts in heartbeats if ts > cutoff)
 
     def _record_task_runtime(
         self,

--- a/celerymon/event_watcher.py
+++ b/celerymon/event_watcher.py
@@ -289,7 +289,7 @@ class EventWatcher:
         now_ts = now.timestamp()
         ttl_cutoff = now_ts - self._in_flight_ttl_sec
         ages: dict[str, float] = {}
-        for entry in self._in_flight.values():
+        for entry in tuple(self._in_flight.values()):
             if entry.expires_ts is not None and entry.expires_ts < now_ts:
                 continue
             if entry.sent_ts < ttl_cutoff:

--- a/celerymon/event_watcher.py
+++ b/celerymon/event_watcher.py
@@ -206,12 +206,8 @@ class EventWatcher:
         else:
             self._worker_last_heartbeat[hostname] = now
 
-    def online_worker_count(
-        self,
-        now: datetime.datetime,
-        ttl_sec: int = _WORKER_HEARTBEAT_TTL_SEC,
-    ) -> int:
-        cutoff = now - datetime.timedelta(seconds=ttl_sec)
+    def online_worker_count(self, now: datetime.datetime) -> int:
+        cutoff = now - datetime.timedelta(seconds=_WORKER_HEARTBEAT_TTL_SEC)
         heartbeats = tuple(self._worker_last_heartbeat.values())
         return sum(1 for ts in heartbeats if ts > cutoff)
 

--- a/celerymon/metrics.py
+++ b/celerymon/metrics.py
@@ -204,13 +204,13 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
                     sum_value=watcher.task_runtime_sec_sum.get(key, 0.0),
                     timestamp=watcher.last_received_timestamp.timestamp(),
                 )
-            queue_wait_acc = 0.0
-            queue_wait_buckets_values: list[tuple[str, float]] = []
-            for i, bound in enumerate(watcher.queue_wait_upper_bounds):
-                queue_wait_acc += watcher.queue_wait_sec[i].get(task_name, 0)
-                queue_wait_buckets_values.append(
-                    (floatToGoString(bound), queue_wait_acc)
+            queue_wait_buckets_values: list[tuple[str, float]] = [
+                (
+                    floatToGoString(bound),
+                    watcher.queue_wait_sec[i].get(task_name, 0),
                 )
+                for i, bound in enumerate(watcher.queue_wait_upper_bounds)
+            ]
             queue_wait_seconds_metric.add_metric(
                 labels=[task_name],
                 buckets=queue_wait_buckets_values,

--- a/celerymon/metrics.py
+++ b/celerymon/metrics.py
@@ -141,6 +141,35 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
             "worker-heartbeat, and worker-offline events."
         ),
     )
+    queue_wait_seconds_metric = HistogramMetricFamily(
+        name="celerymon_events_queue_wait_seconds",
+        documentation=(
+            "Queue wait time (task-sent to task-started) per task name, in seconds."
+        ),
+        labels=["task_name"],
+        unit="seconds",
+    )
+    oldest_queued_task_age_seconds_metric = GaugeMetricFamily(
+        name="celerymon_events_oldest_queued_task_age_seconds",
+        documentation=(
+            "Age of the oldest in-flight task per queue (sent but not yet started), "
+            "in seconds."
+        ),
+        labels=["queue_name"],
+        unit="seconds",
+    )
+    in_flight_evicted_metric = CounterMetricFamily(
+        name="celerymon_events_in_flight_evicted",
+        documentation=(
+            "Count of in-flight entries evicted by reason: failed, revoked, "
+            "expired, ttl (exceeded max age), lru (cache cap hit)."
+        ),
+        labels=["reason"],
+    )
+    in_flight_cache_size_metric = GaugeMetricFamily(
+        name="celerymon_events_in_flight_cache_size",
+        documentation="Current size of the in-flight uuid correlation cache.",
+    )
     if watcher.last_received_timestamp is not None:
         last_received_items = list(
             watcher.last_received_timestamp_per_task_event.items()
@@ -175,10 +204,40 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
                     sum_value=watcher.task_runtime_sec_sum.get(key, 0.0),
                     timestamp=watcher.last_received_timestamp.timestamp(),
                 )
+            queue_wait_acc = 0.0
+            queue_wait_buckets_values: list[tuple[str, float]] = []
+            for i, bound in enumerate(watcher.queue_wait_upper_bounds):
+                queue_wait_acc += watcher.queue_wait_sec[i].get(task_name, 0)
+                queue_wait_buckets_values.append(
+                    (floatToGoString(bound), queue_wait_acc)
+                )
+            queue_wait_seconds_metric.add_metric(
+                labels=[task_name],
+                buckets=queue_wait_buckets_values,
+                sum_value=watcher.queue_wait_sec_sum.get(task_name, 0.0),
+                timestamp=watcher.last_received_timestamp.timestamp(),
+            )
         now = datetime.datetime.now(tz=datetime.UTC)
         online_worker_count_metric.add_metric(
             labels=[],
             value=watcher.online_worker_count(now),
+            timestamp=watcher.last_received_timestamp.timestamp(),
+        )
+        for queue_name, age in watcher.oldest_queued_age_by_queue(now).items():
+            oldest_queued_task_age_seconds_metric.add_metric(
+                labels=[queue_name],
+                value=age,
+                timestamp=watcher.last_received_timestamp.timestamp(),
+            )
+        for reason, count in watcher.eviction_counts().items():
+            in_flight_evicted_metric.add_metric(
+                labels=[reason],
+                value=count,
+                timestamp=watcher.last_received_timestamp.timestamp(),
+            )
+        in_flight_cache_size_metric.add_metric(
+            labels=[],
+            value=watcher.in_flight_cache_size(),
             timestamp=watcher.last_received_timestamp.timestamp(),
         )
     return [
@@ -186,4 +245,8 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
         events_count_metric,
         task_runtime_seconds_metric,
         online_worker_count_metric,
+        queue_wait_seconds_metric,
+        oldest_queued_task_age_seconds_metric,
+        in_flight_evicted_metric,
+        in_flight_cache_size_metric,
     ]

--- a/celerymon/metrics.py
+++ b/celerymon/metrics.py
@@ -142,8 +142,11 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
         ),
     )
     if watcher.last_received_timestamp is not None:
-        for key, timestamp in watcher.last_received_timestamp_per_task_event.items():
-            count = watcher.num_events_per_task_count[key]
+        last_received_items = list(
+            watcher.last_received_timestamp_per_task_event.items()
+        )
+        for key, timestamp in last_received_items:
+            count = watcher.num_events_per_task_count.get(key, 0)
 
             task_name, event_name = key
             last_received_timestamp_seconds_metric.add_metric(
@@ -156,7 +159,7 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
                 value=count,
                 timestamp=timestamp.timestamp(),
             )
-        for task_name in watcher.task_names:
+        for task_name in tuple(watcher.task_names):
             for result in ("success", "failed"):
                 key = (task_name, result)
                 buckets = [

--- a/celerymon/metrics.py
+++ b/celerymon/metrics.py
@@ -159,11 +159,13 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
         for task_name in watcher.task_names:
             for result in ("success", "failed"):
                 key = (task_name, result)
-                acc = 0.0
-                buckets = []
-                for i, bound in enumerate(watcher.upper_bounds):
-                    acc += watcher.task_runtime_sec[i].get(key, 0)
-                    buckets.append((floatToGoString(bound), acc))
+                buckets = [
+                    (
+                        floatToGoString(bound),
+                        watcher.task_runtime_sec[i].get(key, 0),
+                    )
+                    for i, bound in enumerate(watcher.upper_bounds)
+                ]
                 task_runtime_seconds_metric.add_metric(
                     labels=[task_name, result],
                     buckets=buckets,

--- a/celerymon/metrics.py
+++ b/celerymon/metrics.py
@@ -161,8 +161,13 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
     in_flight_evicted_metric = CounterMetricFamily(
         name="celerymon_events_in_flight_evicted",
         documentation=(
-            "Count of in-flight entries evicted by reason: failed, revoked, "
-            "expired, ttl (exceeded max age), lru (cache cap hit)."
+            "Count of in-flight entries evicted from the task-sent/task-started "
+            "correlation cache, labeled by reason. lru: cache cap hit. "
+            "failed_pre_start: task-failed arrived for an entry that never "
+            "reached task-started (does not count tasks that started and then "
+            "failed). revoked_pre_start: task-revoked arrived for an entry that "
+            "never reached task-started. expired: producer-set expires "
+            "timestamp passed. ttl: entry exceeded --in-flight-ttl-sec."
         ),
         labels=["reason"],
     )

--- a/celerymon/metrics.py
+++ b/celerymon/metrics.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import Iterable
 
 import prometheus_client
@@ -85,7 +86,7 @@ def worker_metrics(watcher: WorkerWatcher) -> list[prometheus_client.Metric]:
     active_task_count_metric = GaugeMetricFamily(
         name="celerymon_inspect_worker_held_task_count",
         documentation="Number of tasks held in all workers",
-        labels=["task_name", "state"],
+        labels=["task_name", "state", "hostname"],
     )
     if watcher.last_updated_timestamp is not None:
         last_updated_timestamp_seconds_metric.add_metric(
@@ -100,9 +101,9 @@ def worker_metrics(watcher: WorkerWatcher) -> list[prometheus_client.Metric]:
                 timestamp=watcher.last_updated_timestamp.timestamp(),
             )
         for key, count in watcher.task_count.items():
-            state, task_name = key
+            state, task_name, hostname = key
             active_task_count_metric.add_metric(
-                labels=[task_name, state],
+                labels=[task_name, state, hostname],
                 value=count,
                 timestamp=watcher.last_updated_timestamp.timestamp(),
             )
@@ -125,11 +126,20 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
         documentation="The task event count per task name and event name.",
         labels=["task_name", "event_name"],
     )
-    success_task_runtime_seconds_metric = HistogramMetricFamily(
-        name="celerymon_events_success_task_runtime_seconds",
-        documentation="The task runtime per task name for finished success tasks.",
-        labels=["task_name"],
+    task_runtime_seconds_metric = HistogramMetricFamily(
+        name="celerymon_events_task_runtime_seconds",
+        documentation=(
+            "Task runtime per task name, labeled by result (success|failed)."
+        ),
+        labels=["task_name", "result"],
         unit="seconds",
+    )
+    online_worker_count_metric = GaugeMetricFamily(
+        name="celerymon_events_online_worker_count",
+        documentation=(
+            "Number of workers currently online, derived from worker-online, "
+            "worker-heartbeat, and worker-offline events."
+        ),
     )
     if watcher.last_received_timestamp is not None:
         for key, timestamp in watcher.last_received_timestamp_per_task_event.items():
@@ -147,19 +157,28 @@ def event_metrics(watcher: EventWatcher) -> list[prometheus_client.Metric]:
                 timestamp=timestamp.timestamp(),
             )
         for task_name in watcher.task_names:
-            acc = 0.0
-            buckets = []
-            for i, bound in enumerate(watcher.upper_bounds):
-                acc += watcher.succeeded_task_runtime_sec[i][task_name]
-                buckets.append((floatToGoString(bound), acc))
-            success_task_runtime_seconds_metric.add_metric(
-                labels=[task_name],
-                buckets=buckets,
-                sum_value=watcher.succeeded_task_runtime_sec_sum[task_name],
-                timestamp=watcher.last_received_timestamp.timestamp(),
-            )
+            for result in ("success", "failed"):
+                key = (task_name, result)
+                acc = 0.0
+                buckets = []
+                for i, bound in enumerate(watcher.upper_bounds):
+                    acc += watcher.task_runtime_sec[i].get(key, 0)
+                    buckets.append((floatToGoString(bound), acc))
+                task_runtime_seconds_metric.add_metric(
+                    labels=[task_name, result],
+                    buckets=buckets,
+                    sum_value=watcher.task_runtime_sec_sum.get(key, 0.0),
+                    timestamp=watcher.last_received_timestamp.timestamp(),
+                )
+        now = datetime.datetime.now(tz=datetime.UTC)
+        online_worker_count_metric.add_metric(
+            labels=[],
+            value=watcher.online_worker_count(now),
+            timestamp=watcher.last_received_timestamp.timestamp(),
+        )
     return [
         last_received_timestamp_seconds_metric,
         events_count_metric,
-        success_task_runtime_seconds_metric,
+        task_runtime_seconds_metric,
+        online_worker_count_metric,
     ]

--- a/celerymon/worker_watcher.py
+++ b/celerymon/worker_watcher.py
@@ -14,7 +14,7 @@ from .timer import RepeatTimer
 class WorkerWatcher:
     last_updated_timestamp: datetime.datetime | None
     oldest_started_task_timestamp: dict[str, datetime.datetime]
-    task_count: dict[tuple[str, str], int]
+    task_count: dict[tuple[str, str, str], int]
 
     @classmethod
     def create_started(
@@ -37,28 +37,30 @@ class WorkerWatcher:
 
     def _update(self) -> None:
         oldest_timestamp: dict[str, datetime.datetime] = dict()
-        task_count: dict[tuple[str, str], int] = defaultdict(int)
+        task_count: dict[tuple[str, str, str], int] = defaultdict(int)
 
-        for tasks in (self._inspect.active() or {}).values():
+        for hostname, tasks in (self._inspect.active() or {}).items():
             for task in tasks:
                 if isinstance(task["time_start"], str):
                     start_time = datetime.datetime.fromisoformat(task["time_start"])
                 else:
                     start_time = datetime.datetime.fromtimestamp(task["time_start"])
                 task_name = task["type"]
-                task_count[("active", task_name)] += 1
+                task_count[("active", task_name, hostname)] += 1
                 if task_name not in oldest_timestamp:
                     oldest_timestamp[task_name] = start_time
                 else:
                     oldest_timestamp[task_name] = min(
                         oldest_timestamp[task_name], start_time
                     )
-        for tasks in (self._inspect.reserved() or {}).values():
+        for hostname, tasks in (self._inspect.reserved() or {}).items():
             for task in tasks:
-                task_count[("reserved", task["type"])] += 1
-        for scheduled_tasks in (self._inspect.scheduled() or {}).values():
+                task_count[("reserved", task["type"], hostname)] += 1
+        for hostname, scheduled_tasks in (self._inspect.scheduled() or {}).items():
             for scheduled_task in scheduled_tasks:
-                task_count[("scheduled", scheduled_task["request"]["type"])] += 1
+                task_count[
+                    ("scheduled", scheduled_task["request"]["type"], hostname)
+                ] += 1
 
         self.last_updated_timestamp = datetime.datetime.now(tz=datetime.UTC)
         self.oldest_started_task_timestamp = oldest_timestamp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celerymon"
-version = "0.1.3"
+version = "0.1.9"
 description = ""
 authors = [
     { name = "Masaya Suzuki", email = "masaya@aviator.co" },

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ wheels = [
 
 [[package]]
 name = "celerymon"
-version = "0.1.3"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "celery", extra = ["redis"] },


### PR DESCRIPTION
closes queue-wait and stuck-task blindspots

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"metrics-easy-wins","parentHead":"5dfb4a0200d7944c3f9cc14cac976a69016210d0","parentPull":28,"trunk":"main"}
```
-->
